### PR TITLE
Translate app text to English and add image assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DiveFive — Bitácora de buceo</title>
-    <meta name="description" content="App de buceo para iOS que permite registrar inmersiones, importar datos de Apple Watch y UDDF, mapear sitios y obtener estadísticas." />
-    <meta property="og:title" content="DiveFive — Bitácora de buceo" />
-    <meta property="og:description" content="App de buceo para iOS que permite registrar inmersiones, importar datos de Apple Watch y UDDF, mapear sitios y obtener estadísticas." />
+    <title>DiveFive — Smart dive log</title>
+    <meta name="description" content="DiveFive is a smart dive logging app that lets you record dives, import Apple Watch and UDDF data, map sites and track stats." />
+    <meta property="og:title" content="DiveFive — Smart dive log" />
+    <meta property="og:description" content="DiveFive is a smart dive logging app that lets you record dives, import Apple Watch and UDDF data, map sites and track stats." />
     <meta property="og:image" content="/diving-hero.jpg" />
   </head>
   <body>

--- a/public/ASSETS.md
+++ b/public/ASSETS.md
@@ -1,11 +1,9 @@
 # DiveFive Landing Assets
 
-The following image files should be placed in this directory:
+Place the following image files in this directory before building:
 
-- diving-hero.jpg – hero background photo
-- app-mock1.png – app screenshot one
-- app-mock2.png – app screenshot two
-- logo.svg – DiveFive logo used in footer
+- diving-hero.jpg – hero background photo for social previews
+- logo.svg – site favicon
 - icon-watch.svg – watch/HealthKit icon
 - icon-map.svg – map icon
 - icon-log.svg – dive log icon

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -6,11 +6,11 @@ import DiveDetail from "@/assets/images/DiveDetail.png";
 <template>
   <section class="relative text-white text-center py-20 overflow-hidden">
     <div class="absolute inset-0 bg-gradient-to-b from-cyan-900 to-cyan-600"></div>
-    <img :src="DiveDetail" alt="Buceo" class="absolute inset-0 w-full h-full object-cover opacity-40" @error="e=>e.target.style.display='none'" />
+    <img :src="DiveDetail" alt="Diving" class="absolute inset-0 w-full h-full object-cover opacity-40" @error="e=>e.target.style.display='none'" />
     <div class="relative z-10 max-w-2xl mx-auto px-4">
-      <h1 class="text-4xl md:text-5xl font-bold mb-4">DiveFive — tu bitácora de buceo inteligente</h1>
-      <p class="mb-6">App de buceo para iOS que permite registrar inmersiones, importar datos de Apple Watch y UDDF, mapear sitios y obtener estadísticas.</p>
-      <button class="bg-blue-600 text-white px-6 py-3 rounded">Próximamente en App Store</button>
+      <h1 class="text-4xl md:text-5xl font-bold mb-4">DiveFive — your smart dive log</h1>
+      <p class="mb-6">iOS dive app that lets you record dives, import Apple Watch and UDDF data, map sites, and track stats.</p>
+      <button class="bg-blue-600 text-white px-6 py-3 rounded">Coming soon on the App Store</button>
     </div>
   </section>
 </template>

--- a/src/components/Steps.vue
+++ b/src/components/Steps.vue
@@ -1,16 +1,16 @@
 <script setup>
 import { reactive } from 'vue'
 const steps = reactive([
-  { icon: '/icon-watch.svg', text: '1. Registra tu inmersión', error: false },
-  { icon: '/icon-map.svg', text: '2. Agrega ubicación y detalles', error: false },
-  { icon: '/icon-log.svg', text: '3. Analiza tus estadísticas', error: false }
+  { icon: '/icon-watch.svg', text: '1. Record your dive', error: false },
+  { icon: '/icon-map.svg', text: '2. Add location and details', error: false },
+  { icon: '/icon-log.svg', text: '3. Analyze your stats', error: false }
 ])
 </script>
 
 <template>
   <section class="py-16 bg-gray-100">
     <div class="max-w-5xl mx-auto px-4">
-      <h2 class="text-2xl font-bold text-center mb-10">Cómo funciona</h2>
+      <h2 class="text-2xl font-bold text-center mb-10">How it works</h2>
       <div class="grid md:grid-cols-3 gap-8 text-center">
         <div v-for="(step, idx) in steps" :key="idx">
           <div class="mx-auto mb-4 h-12 w-12 flex items-center justify-center">

--- a/src/pages/Faq.vue
+++ b/src/pages/Faq.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-8">
     <h1 class="text-3xl font-bold mb-4">FAQ</h1>
-    <p>Preguntas frecuentes sobre DiveFive.</p>
+    <p>Frequently asked questions about DiveFive.</p>
   </div>
 </template>

--- a/src/pages/Features.vue
+++ b/src/pages/Features.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-8">
     <h1 class="text-3xl font-bold mb-4">Features</h1>
-    <p>Detalles de las características de DiveFive.</p>
+    <p>Details about DiveFive features.</p>
   </div>
 </template>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -5,12 +5,18 @@ import Steps from '@/components/Steps.vue'
 import ScreenshotGrid from '@/components/ScreenshotGrid.vue'
 
 const benefits = [
-  { title: 'Registra tus inmersiones', description: 'Mantén un registro seguro y organizado de cada buceo.', icon: '/icon-watch.svg' },
-  { title: 'Explora nuevos sitios', description: 'Mapas interactivos para planear y descubrir lugares.', icon: '/icon-map.svg' },
-  { title: 'Comparte con la comunidad', description: 'Conecta con otros buzos y comparte tus aventuras.', icon: '/icon-log.svg' }
+  { title: 'Log your dives', description: 'Keep a secure, organized record of every dive.', icon: '/icon-watch.svg' },
+  { title: 'Explore new sites', description: 'Interactive maps to plan and discover locations.', icon: '/icon-map.svg' },
+  { title: 'Share with the community', description: 'Connect with other divers and share your adventures.', icon: '/icon-log.svg' }
 ]
 
-const features = ['HealthKit', 'UDDF', 'Mapas de sitios', 'Planner', 'Estadísticas']
+const features = [
+  'Import dive workouts from HealthKit',
+  'Import UDDF files',
+  'Track dive sites and locations',
+  'Create and log pre-dive plans',
+  'Notice trends in performance and enjoyment'
+]
 </script>
 
 <template>
@@ -18,17 +24,17 @@ const features = ['HealthKit', 'UDDF', 'Mapas de sitios', 'Planner', 'Estadísti
     <!-- Hero -->
     <Hero />
 
-    <!-- Beneficios -->
+    <!-- Benefits -->
     <section class="py-16 bg-gray-100">
       <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 px-4">
         <FeatureCard v-for="(b, idx) in benefits" :key="idx" v-bind="b" />
       </div>
     </section>
 
-    <!-- Funciones -->
+    <!-- Features -->
     <section class="py-16">
       <div class="max-w-5xl mx-auto px-4">
-        <h2 class="text-2xl font-bold text-center mb-10">Funciones</h2>
+        <h2 class="text-2xl font-bold text-center mb-10">Features</h2>
         <ul class="grid md:grid-cols-2 gap-6">
           <li v-for="f in features" :key="f" class="p-4 border rounded">
             {{ f }}

--- a/src/pages/PressKit.vue
+++ b/src/pages/PressKit.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-8">
     <h1 class="text-3xl font-bold mb-4">Press Kit</h1>
-    <p>Recursos de prensa de DiveFive.</p>
+    <p>DiveFive press resources.</p>
   </div>
 </template>

--- a/src/pages/Privacy.vue
+++ b/src/pages/Privacy.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-8">
     <h1 class="text-3xl font-bold mb-4">Privacy</h1>
-    <p>Política de privacidad de DiveFive.</p>
+    <p>DiveFive privacy policy.</p>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Translate landing page, hero, steps, and other pages to English
- Add placeholder public images and adjust ignore rules to ensure icons and logo display
- Remove placeholder public images and restore ignore rules for manual asset addition

## Testing
- `npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_b_68b9e1248c3c8332a08a0cb27875ef33